### PR TITLE
Metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -787,6 +787,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f86ba2052aebccc42cbbb3ed234b8b13ce76f75c3551a303cb2bcffcff12bb14"
 dependencies = [
  "bitflags",
+ "memchr",
+ "pulldown-cmark-escape",
+ "unicase",
+]
+
+[[package]]
+name = "pulldown-cmark"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e8bbe1a966bd2f362681a44f6edce3c2310ac21e4d5067a6e7ec396297a6ea0"
+dependencies = [
+ "bitflags",
  "getopts",
  "memchr",
  "pulldown-cmark-escape",
@@ -798,15 +810,6 @@ name = "pulldown-cmark-escape"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "007d8adb5ddab6f8e3f491ac63566a7d5002cc7ed73901f72057943fa71ae1ae"
-
-[[package]]
-name = "pulldown-cmark-frontmatter"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49c897db7dac0f10814066f1b5176a130cc951feb33f1a2643bd3094203bd081"
-dependencies = [
- "pulldown-cmark",
-]
 
 [[package]]
 name = "quote"
@@ -833,7 +836,7 @@ dependencies = [
  "beef",
  "fnv",
  "logos",
- "pulldown-cmark",
+ "pulldown-cmark 0.12.2",
  "ramhorns-derive",
 ]
 
@@ -1010,8 +1013,7 @@ version = "0.1.0"
 dependencies = [
  "axum",
  "clap",
- "pulldown-cmark",
- "pulldown-cmark-frontmatter",
+ "pulldown-cmark 0.13.0",
  "ramhorns",
  "serde",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -965,6 +965,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1016,6 +1029,7 @@ dependencies = [
  "pulldown-cmark 0.13.0",
  "ramhorns",
  "serde",
+ "serde_yaml",
  "tokio",
  "toml",
  "tower-http",
@@ -1233,6 +1247,12 @@ name = "unicode-width"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a1a07cc7db3810833284e8d372ccdc6da29741639ecc70c9ec107df0fa6154c"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "utf8parse"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ clap = { version = "4.5.45", features = ["derive"] }
 pulldown-cmark = { version = "0.13.0", features = ["html"] }
 ramhorns = "1.0.1"
 serde = { version = "1.0.219", features = ["derive"] }
+serde_yaml = "0.9.34"
 tokio = { version = "1.47.1", features = ["full"] }
 toml = "0.9.5"
 tower-http = { version = "0.6.6", features = ["full", "timeout"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,8 +6,7 @@ edition = "2024"
 [dependencies]
 axum = "0.8.4"
 clap = { version = "4.5.45", features = ["derive"] }
-pulldown-cmark = { version = "0.12.0", features = ["html"] }
-pulldown-cmark-frontmatter = "0.4.0"
+pulldown-cmark = { version = "0.13.0", features = ["html"] }
 ramhorns = "1.0.1"
 serde = { version = "1.0.219", features = ["derive"] }
 tokio = { version = "1.47.1", features = ["full"] }

--- a/content/example/index.md
+++ b/content/example/index.md
@@ -1,6 +1,6 @@
-```toml
-title = "test"
-styles = ["test", "main"]
-```
+---
+title: test
+styles: ['test', 'main']
+---
 
 # nested example

--- a/content/higher/index.md
+++ b/content/higher/index.md
@@ -1,6 +1,6 @@
-```toml
-title = "test higher"
-styles = ["test higher style", "test2", "dark"]
-```
+---
+title: test higher
+styles: ['test higher style', 'test2', 'dark']
+---
 
 # test higher

--- a/content/index.md
+++ b/content/index.md
@@ -1,6 +1,6 @@
-```toml
-title = "sdadsa"
-styles = ["main", "dark"]
-```
+---
+title: sdadsa
+styles: 0
+---
 
 # Testes

--- a/content/index.md
+++ b/content/index.md
@@ -1,6 +1,6 @@
 ---
 title: sdadsa
-styles: 0
+styles: ['main']
 ---
 
 # Testes

--- a/content/posts/post_test.md
+++ b/content/posts/post_test.md
@@ -1,3 +1,3 @@
-```toml
-title = "post_1"
-```
+---
+title: post 1
+---

--- a/src/cmd/build.rs
+++ b/src/cmd/build.rs
@@ -157,7 +157,7 @@ pub fn build() {
             let name = path.file_name().unwrap().to_str().unwrap().to_string();
             let md_string = fs::read_to_string(path).unwrap();
 
-            println!("processing:{}", name);
+            println!("processing:{}", path.display());
 
             let (frontmatter_string, content) = convert(&md_string);
 

--- a/src/cmd/build.rs
+++ b/src/cmd/build.rs
@@ -161,95 +161,93 @@ pub fn build() {
 
             let (frontmatter_string, content) = convert(&md_string);
 
-            /*
-                let frontmatter: Frontmatter = toml::from_str(&frontmatter_string)
-                    .expect("could not convert frontmatter to struct");
+            let frontmatter: Frontmatter = serde_yaml::from_str(&frontmatter_string)
+                .expect("could not convert frontmatter to struct");
 
-                //println!("{:?}", frontmatter);
+            //println!("{:?}", frontmatter);
 
-                let mut thing_styles = Vec::new();
-                if let Some(styles_strings) = frontmatter.styles {
-                    for style in &styles {
-                        if styles_strings.contains(&style.name) {
-                            thing_styles.push(style.clone());
-                        }
+            let mut thing_styles = Vec::new();
+            if let Some(styles_strings) = frontmatter.styles {
+                for style in &styles {
+                    if styles_strings.contains(&style.name) {
+                        thing_styles.push(style.clone());
                     }
                 }
+            }
 
-                // todo get this from mustache bro
-                let mut thing_mustache = mustaches
-                    .iter()
-                    .find(|m| m.name == "base")
-                    .cloned()
-                    .unwrap();
+            // todo get this from mustache bro
+            let mut thing_mustache = mustaches
+                .iter()
+                .find(|m| m.name == "base")
+                .cloned()
+                .unwrap();
 
-                if let Some(mustache_name) = frontmatter.template {
-                    println!("{:?}", mustache_name);
-                    for avail_mustache in &mustaches {
-                        if avail_mustache.name == mustache_name {
-                            thing_mustache = avail_mustache.clone();
-                        }
+            if let Some(mustache_name) = frontmatter.template {
+                println!("{:?}", mustache_name);
+                for avail_mustache in &mustaches {
+                    if avail_mustache.name == mustache_name {
+                        thing_mustache = avail_mustache.clone();
                     }
                 }
+            }
 
-                println!("loaded_styles:{:?}", thing_styles);
-                println!("loaded_templ:{:?}", thing_mustache);
+            println!("loaded_styles:{:?}", thing_styles);
+            println!("loaded_templ:{:?}", thing_mustache);
 
-                // HOLY FUCK LMAO
-                let relative_path = path.strip_prefix("./content").unwrap();
-                let count = relative_path.components().count();
-                let redirect_path = if count <= 1 {
-                    "./"
-                } else {
-                    &format!("{}/", "..".repeat(count - 1))
-                };
+            // HOLY FUCK LMAO
+            let relative_path = path.strip_prefix("./content").unwrap();
+            let count = relative_path.components().count();
+            let redirect_path = if count <= 1 {
+                "./"
+            } else {
+                &format!("{}/", "..".repeat(count - 1))
+            };
 
-                // thing is only used when building
-                // so we can pragmatically store what we need
-                // to build that file out
-                // methinks :shrug:
-                let mut thing = TheThing {
-                    name,
-                    path: path.to_str().unwrap().to_string(),
-                    content,
-                    styles: thing_styles,
-                    mustache: thing_mustache,
-                };
+            // thing is only used when building
+            // so we can pragmatically store what we need
+            // to build that file out
+            // methinks :shrug:
+            let mut thing = TheThing {
+                name,
+                path: path.to_str().unwrap().to_string(),
+                content,
+                styles: thing_styles,
+                mustache: thing_mustache,
+            };
 
-                (0..thing.styles.len()).for_each(|n| {
-                    thing.styles.index_mut(n).path =
-                        format!("{}{}", redirect_path, thing.styles.index(n).path);
-                });
+            (0..thing.styles.len()).for_each(|n| {
+                thing.styles.index_mut(n).path =
+                    format!("{}{}", redirect_path, thing.styles.index(n).path);
+            });
 
-                // now build out the html
-                let source = fs::read_to_string(thing.mustache.path).expect("mustache path is invalid");
-                let tpl = Template::new(source).unwrap();
+            // now build out the html
+            let source = fs::read_to_string(thing.mustache.path).expect("mustache path is invalid");
+            let tpl = Template::new(source).unwrap();
 
-                let mut rendered = tpl.render(&RenderedContent {
-                    title: frontmatter.title,
-                    content: thing.content,
-                });
+            let mut rendered = tpl.render(&RenderedContent {
+                title: frontmatter.title,
+                content: thing.content,
+            });
 
-                let mut link = String::new();
-                for style in thing.styles {
-                    link.push_str(&format!(
-                        "<link rel=\"stylesheet\" href=\"{}\">\n",
-                        style.path
-                    ));
-                }
+            let mut link = String::new();
+            for style in thing.styles {
+                link.push_str(&format!(
+                    "<link rel=\"stylesheet\" href=\"{}\">\n",
+                    style.path
+                ));
+            }
 
-                rendered = link + &rendered;
+            rendered = link + &rendered;
 
-                println!("{}\n", rendered);
-                let out = Path::new("./public")
-                    .join(relative_path)
-                    .with_extension("html");
+            println!("{}\n", rendered);
+            let out = Path::new("./public")
+                .join(relative_path)
+                .with_extension("html");
 
-                fs::create_dir_all(out.parent().unwrap()).unwrap();
+            fs::create_dir_all(out.parent().unwrap()).unwrap();
 
-                fs::write(&out, rendered).unwrap();
-                println!("created: {}", out.display());
-            */
+            fs::write(&out, rendered).unwrap();
+            println!("created: {}", out.display());
         }
     }
 }

--- a/src/cmd/build.rs
+++ b/src/cmd/build.rs
@@ -161,93 +161,95 @@ pub fn build() {
 
             let (frontmatter_string, content) = convert(&md_string);
 
-            let frontmatter: Frontmatter = toml::from_str(&frontmatter_string)
-                .expect("could not convert frontmatter to struct");
+            /*
+                let frontmatter: Frontmatter = toml::from_str(&frontmatter_string)
+                    .expect("could not convert frontmatter to struct");
 
-            //println!("{:?}", frontmatter);
+                //println!("{:?}", frontmatter);
 
-            let mut thing_styles = Vec::new();
-            if let Some(styles_strings) = frontmatter.styles {
-                for style in &styles {
-                    if styles_strings.contains(&style.name) {
-                        thing_styles.push(style.clone());
+                let mut thing_styles = Vec::new();
+                if let Some(styles_strings) = frontmatter.styles {
+                    for style in &styles {
+                        if styles_strings.contains(&style.name) {
+                            thing_styles.push(style.clone());
+                        }
                     }
                 }
-            }
 
-            // todo get this from mustache bro
-            let mut thing_mustache = mustaches
-                .iter()
-                .find(|m| m.name == "base")
-                .cloned()
-                .unwrap();
+                // todo get this from mustache bro
+                let mut thing_mustache = mustaches
+                    .iter()
+                    .find(|m| m.name == "base")
+                    .cloned()
+                    .unwrap();
 
-            if let Some(mustache_name) = frontmatter.template {
-                println!("{:?}", mustache_name);
-                for avail_mustache in &mustaches {
-                    if avail_mustache.name == mustache_name {
-                        thing_mustache = avail_mustache.clone();
+                if let Some(mustache_name) = frontmatter.template {
+                    println!("{:?}", mustache_name);
+                    for avail_mustache in &mustaches {
+                        if avail_mustache.name == mustache_name {
+                            thing_mustache = avail_mustache.clone();
+                        }
                     }
                 }
-            }
 
-            println!("loaded_styles:{:?}", thing_styles);
-            println!("loaded_templ:{:?}", thing_mustache);
+                println!("loaded_styles:{:?}", thing_styles);
+                println!("loaded_templ:{:?}", thing_mustache);
 
-            // HOLY FUCK LMAO
-            let relative_path = path.strip_prefix("./content").unwrap();
-            let count = relative_path.components().count();
-            let redirect_path = if count <= 1 {
-                "./"
-            } else {
-                &format!("{}/", "..".repeat(count - 1))
-            };
+                // HOLY FUCK LMAO
+                let relative_path = path.strip_prefix("./content").unwrap();
+                let count = relative_path.components().count();
+                let redirect_path = if count <= 1 {
+                    "./"
+                } else {
+                    &format!("{}/", "..".repeat(count - 1))
+                };
 
-            // thing is only used when building
-            // so we can pragmatically store what we need
-            // to build that file out
-            // methinks :shrug:
-            let mut thing = TheThing {
-                name,
-                path: path.to_str().unwrap().to_string(),
-                content,
-                styles: thing_styles,
-                mustache: thing_mustache,
-            };
+                // thing is only used when building
+                // so we can pragmatically store what we need
+                // to build that file out
+                // methinks :shrug:
+                let mut thing = TheThing {
+                    name,
+                    path: path.to_str().unwrap().to_string(),
+                    content,
+                    styles: thing_styles,
+                    mustache: thing_mustache,
+                };
 
-            (0..thing.styles.len()).for_each(|n| {
-                thing.styles.index_mut(n).path =
-                    format!("{}{}", redirect_path, thing.styles.index(n).path);
-            });
+                (0..thing.styles.len()).for_each(|n| {
+                    thing.styles.index_mut(n).path =
+                        format!("{}{}", redirect_path, thing.styles.index(n).path);
+                });
 
-            // now build out the html
-            let source = fs::read_to_string(thing.mustache.path).expect("mustache path is invalid");
-            let tpl = Template::new(source).unwrap();
+                // now build out the html
+                let source = fs::read_to_string(thing.mustache.path).expect("mustache path is invalid");
+                let tpl = Template::new(source).unwrap();
 
-            let mut rendered = tpl.render(&RenderedContent {
-                title: frontmatter.title,
-                content: thing.content,
-            });
+                let mut rendered = tpl.render(&RenderedContent {
+                    title: frontmatter.title,
+                    content: thing.content,
+                });
 
-            let mut link = String::new();
-            for style in thing.styles {
-                link.push_str(&format!(
-                    "<link rel=\"stylesheet\" href=\"{}\">\n",
-                    style.path
-                ));
-            }
+                let mut link = String::new();
+                for style in thing.styles {
+                    link.push_str(&format!(
+                        "<link rel=\"stylesheet\" href=\"{}\">\n",
+                        style.path
+                    ));
+                }
 
-            rendered = link + &rendered;
+                rendered = link + &rendered;
 
-            println!("{}\n", rendered);
-            let out = Path::new("./public")
-                .join(relative_path)
-                .with_extension("html");
+                println!("{}\n", rendered);
+                let out = Path::new("./public")
+                    .join(relative_path)
+                    .with_extension("html");
 
-            fs::create_dir_all(out.parent().unwrap()).unwrap();
+                fs::create_dir_all(out.parent().unwrap()).unwrap();
 
-            fs::write(&out, rendered).unwrap();
-            println!("created: {}", out.display());
+                fs::write(&out, rendered).unwrap();
+                println!("created: {}", out.display());
+            */
         }
     }
 }

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -1,20 +1,30 @@
-use pulldown_cmark_frontmatter::FrontmatterExtractor;
+use pulldown_cmark::{Event, MetadataBlockKind, Options, Tag, TextMergeStream};
 
 pub fn convert(md_string: &str) -> (String, String) {
-    let mut extractor = FrontmatterExtractor::new(pulldown_cmark::Parser::new(md_string));
-    let mut html_output = String::new();
-    pulldown_cmark::html::push_html(&mut html_output, &mut extractor);
+    let mut options = Options::empty();
+    options.insert(Options::ENABLE_YAML_STYLE_METADATA_BLOCKS);
+    options.insert(Options::ENABLE_PLUSES_DELIMITED_METADATA_BLOCKS);
+    let parser = pulldown_cmark::Parser::new_ext(md_string, options);
+    let iterator = TextMergeStream::new(parser);
 
-    let frontmatter = extractor.frontmatter.expect("no frontmatter detected");
-    let code_block = frontmatter
-        .code_block
-        .expect("code block not detected")
-        .source
-        .to_string();
+    for event in iterator {
+        match event {
+            Event::Start(tag) => {
+                if tag == Tag::MetadataBlock(MetadataBlockKind::YamlStyle) {
+                    println!()
+                }
+            }
+            _ => {}
+        }
+    }
+
+    //let mut html_output = String::new();
+    //pulldown_cmark::html::push_html(&mut html_output, parser);
+    //println!("{html_output}");
 
     //println!("{}", code_block);
 
     // code_block.source.into_string()
 
-    (code_block, html_output)
+    ("fuck u".to_string(), "fuck u".to_string())
 }

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -1,22 +1,37 @@
-use pulldown_cmark::{Event, MetadataBlockKind, Options, Tag, TextMergeStream};
+use pulldown_cmark::{Event, MetadataBlockKind, Options, Tag, TagEnd};
 
 pub fn convert(md_string: &str) -> (String, String) {
     let mut options = Options::empty();
     options.insert(Options::ENABLE_YAML_STYLE_METADATA_BLOCKS);
     options.insert(Options::ENABLE_PLUSES_DELIMITED_METADATA_BLOCKS);
-    let parser = pulldown_cmark::Parser::new_ext(md_string, options);
-    let iterator = TextMergeStream::new(parser);
+    let mut inside = false;
 
-    for event in iterator {
-        match event {
-            Event::Start(tag) => {
-                if tag == Tag::MetadataBlock(MetadataBlockKind::YamlStyle) {
-                    println!()
+    let parser: Vec<_> = pulldown_cmark::Parser::new_ext(md_string, options)
+        .map(|event| match event {
+            Event::Start(tag) => match tag {
+                Tag::MetadataBlock(kind) => {
+                    if kind == MetadataBlockKind::YamlStyle {
+                        inside = true;
+                    }
+                }
+                _ => {}
+            },
+            Event::End(tag) => match tag {
+                TagEnd::MetadataBlock(kind) => {
+                    if kind == MetadataBlockKind::YamlStyle {
+                        inside = false;
+                    }
+                }
+                _ => {}
+            },
+            Event::Text(text) => {
+                if inside {
+                    println!("{:?}", text);
                 }
             }
             _ => {}
-        }
-    }
+        })
+        .collect();
 
     //let mut html_output = String::new();
     //pulldown_cmark::html::push_html(&mut html_output, parser);


### PR DESCRIPTION
Didn't realize `pulldown_cmark` has YAML "frontmatter" support using their Metadata Block.
Removing the need for [pulldown_cmark_frontmatter](https://github.com/khonsulabs/pulldown-cmark-frontmatter). Does use `serde_yaml` tho.