### PR TITLE
fix(serve): limit metadata check to designated watch paths

### DIFF
--- a/src/cmd/serve.rs
+++ b/src/cmd/serve.rs
@@ -205,16 +205,20 @@ fn handle_events(mut stream: TcpStream, reloader: &Reloader) -> std::io::Result<
 fn check_metadata(path: &Path) -> std::io::Result<HashMap<PathBuf, SystemTime>> {
     let mut map = HashMap::new();
 
-    for entry in WalkDir::new(path)
-        .follow_links(true)
-        .follow_root_links(true)
-    {
-        let path = entry?.path().to_owned();
-        let modified = fs::metadata(&path)?.modified()?;
+    for watch in PATHS_TO_WATCH {
+        let root = path.join(watch);
 
-        map.insert(path, modified);
+        for entry in WalkDir::new(&root)
+            .follow_links(true)
+            .follow_root_links(true)
+        {
+            let path = entry?.path().to_owned();
+            let modified = fs::metadata(&path)?.modified()?;
 
-        //println!("{:#?}", metadata.modified()?);
+            map.insert(path, modified);
+
+            //println!("{:#?}", metadata.modified()?);
+        }
     }
 
     Ok(map)


### PR DESCRIPTION
The `check_metadata` function now iterates through `PATHS_TO_WATCH`. This fixes the issue that only specified directories are scanned for metadata changes, rather than walking the entire root path which causes an infinitely looping rebuild, since the root dir contains new changes from the ./public dir.