### PR TITLE
feat: add additional context for plugin templates

### DIFF
--- a/docs/plugins/3d_viewer.html
+++ b/docs/plugins/3d_viewer.html
@@ -1,6 +1,6 @@
 <model-viewer
   alt="NeilArmstrong"
-  src="{{ args.src }}"
+  src="{{ site_url }}{{ args.src }}"
   shadow-intensity="1"
   camera-controls
   touch-action="pan-y"

--- a/src/cmd/build.rs
+++ b/src/cmd/build.rs
@@ -153,6 +153,12 @@ pub fn build(path: &Path, is_local: bool, out: Option<&Path>, drafts: bool) -> R
                 Ok(t) => t
                     .render(context! {
                         args => &plugin.args,
+                        title => thing.frontmatter.title,
+                        content => thing.content,
+                        frontmatter => thing.frontmatter,
+                        headings => thing.headings,
+                        sections,
+                        most_recent,
                     })
                     .unwrap(),
                 Err(_) => String::new(),


### PR DESCRIPTION
Fixes the broken url-ing for the docs by adding all the context from the regular html templates for the plugin templates. 